### PR TITLE
Fix container attributes loss

### DIFF
--- a/src/elements/containerelement.js
+++ b/src/elements/containerelement.js
@@ -6,6 +6,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import { downcastTemplateElement, getModelAttributes } from '../utils/conversion';
 import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
+import { postfixTemplateElement } from '@amazee/ckeditor5-template/src/utils/integrity';
 
 import TemplateEditing from '../templateediting';
 import PlaceholderElement from './placeholderelement';
@@ -51,6 +52,9 @@ export default class ContainerElement extends Plugin {
 				return templateElement.parent ? el : toWidget( el, viewWriter );
 			}
 		} ) );
+
+		// Postfix elements to make sure a templates structure is always correct.
+		this.editor.templates.registerPostFixer( [ 'container' ], postfixTemplateElement );
 	}
 }
 


### PR DESCRIPTION
The `TemplateEditing. _postfixElement` ([code](https://github.com/AmazeeLabs/ckeditor5-template/blob/21bcb140ac1f4853807cd87a624a2cd47ea7f792/src/templateediting.js#L235-L255)) does not work for the element types having no own postfixers. As a quick-fix, I added a postfix in the same way as it's done in `textconstraintelement.js`.

But I also have few questions.

1. Why it's required to have a postfixer on an element type to get `TemplateEditing. _postfixElement` working?

2. This code:
https://github.com/AmazeeLabs/ckeditor5-template/blob/21bcb140ac1f4853807cd87a624a2cd47ea7f792/src/templateediting.js#L242-L244
It changes the `item`, but does not set `changed` to `true`. Is this correct?

